### PR TITLE
fix(contracts): circular imports, cargo file loading

### DIFF
--- a/src/commands/contracts/instantiate.ts
+++ b/src/commands/contracts/instantiate.ts
@@ -190,7 +190,9 @@ export default class ContractsInstantiate extends BaseCommand<typeof ContractsIn
       throw new NotFoundError("Pass either the Contract name in the arguments, or the '--code' flag.");
     }
 
-    await config.assertIsValidWorkspace();
+    if (this.args.contract) {
+      await config.assertIsValidWorkspace();
+    }
 
     const codeId = this.getCodeId(config);
     const contractInstance = this.args.contract ? config.contractsInstance.getContractByName(this.args.contract) : undefined;

--- a/src/parameters/arguments/chain.ts
+++ b/src/parameters/arguments/chain.ts
@@ -1,6 +1,6 @@
 import { Args } from '@oclif/core';
 
-import { ParamsChainOptionalFlag } from '../flags';
+import { ParamsChainOptionalFlag } from '@/parameters/flags/chain';
 
 /**
  * Definition of Chain id argument that is required

--- a/src/parameters/arguments/stdinInput.ts
+++ b/src/parameters/arguments/stdinInput.ts
@@ -4,7 +4,7 @@ import { Args } from '@oclif/core';
  * Definition of Standard input argument
  */
 export const ParamsStdinInputArg = {
-  name: 'piped',
+  name: 'stdInput',
   required: false,
   hidden: true,
 };

--- a/src/parameters/flags/msgArgs.ts
+++ b/src/parameters/flags/msgArgs.ts
@@ -4,7 +4,7 @@ import { Flags, Interfaces } from '@oclif/core';
 import _ from 'lodash';
 
 import { NotFoundError, OnlyOneArgSourceError } from '@/exceptions';
-import { StdinInputArg } from '@/parameters/arguments';
+import { StdinInputArg } from '@/parameters/arguments/stdinInput';
 import { JsonObject } from '@/types';
 
 export const ContractMsgArg = {

--- a/test/commands/contracts/instantiate.test.ts
+++ b/test/commands/contracts/instantiate.test.ts
@@ -47,11 +47,31 @@ describe('contracts instantiate', () => {
     .stdout()
     .command(['contracts instantiate', contractName, `--args=${contractArgument}`, `--from=${aliceAccountName}`, '--json'])
     .it('Prints json output', ctx => {
-      expect(ctx.stdout).to.not.contain('uploaded');
+      expect(ctx.stdout).to.not.contain('instantiated');
       expect(ctx.stdout).to.contain(dummyInstantiateTransaction.transactionHash);
       expect(ctx.stdout).to.contain(dummyInstantiateTransaction.contractAddress);
       expect(ctx.stdout).to.contain(dummyInstantiateTransaction.gasUsed);
     });
+
+  describe('with code-id flag, without workspace files', () => {
+    before(() => {
+      configStubs.stubbedAssertIsValidWorkspace?.restore();
+    });
+
+    after(() => {
+      configStubs.assertIsValidWorkspace();
+    });
+
+    test
+      .stdout()
+      .command(['contracts instantiate', '--code=1', '--label=test', `--args=${contractArgument}`, `--from=${aliceAccountName}`, '--json'])
+      .it('Prints json output', ctx => {
+        expect(ctx.stdout).to.not.contain('instantiated');
+        expect(ctx.stdout).to.contain(dummyInstantiateTransaction.transactionHash);
+        expect(ctx.stdout).to.contain(dummyInstantiateTransaction.contractAddress);
+        expect(ctx.stdout).to.contain(dummyInstantiateTransaction.gasUsed);
+      });
+  });
 
   test
     .stdout()


### PR DESCRIPTION
Some imports in `parameters` directory would return undefined because they had circular imports for the `arguments` and `flags` index file.

Also there was an unnecessary cargo file/workspace check when the instantiate command recieves the code id directly as an argument.